### PR TITLE
Update mongoose to ~3.8.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "angular": "1.2.22",
     "todomvc-common": "~0.1.4",
     "express"    : "~4.7.2",
-    "mongoose"   : "~3.6.2",
+    "mongoose"   : "~3.8.1",
     "morgan"	 : "~1.2.2",
     "body-parser": "~1.5.2",
     "method-override": "~2.1.2",


### PR DESCRIPTION
Mongoose 3.6.2 fails to install with the following message:
`npm WARN package.json mongoose@3.6.20 bugs.email field must be a string email. Deleted.`
According to https://github.com/LearnBoost/mongoose/issues/2543 this has been solved in 3.8.
